### PR TITLE
Ensure that transformFor is available on json api serializer

### DIFF
--- a/packages/ember-data/lib/adapters.js
+++ b/packages/ember-data/lib/adapters.js
@@ -3,9 +3,11 @@
 */
 
 import FixtureAdapter from "ember-data/adapters/fixture-adapter";
+import JSONAPIAdapter from "ember-data/adapters/json-api-adapter";
 import RESTAdapter from "ember-data/adapters/rest-adapter";
 
 export {
-  RESTAdapter,
-  FixtureAdapter
+  FixtureAdapter,
+  JSONAPIAdapter,
+  RESTAdapter
 };

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -53,8 +53,6 @@ export default Adapter.extend(BuildURLMixin, {
     return this.ajax(this.buildURL(type.typeKey, query, null, 'findQuery'), 'GET', { data: query });
   },
 
-
-
   findBelongsTo: function(store, snapshot, link, relationship) {
     return this._findRelationship(store, snapshot, link, relationship, 'findBelongsTo');
   },
@@ -71,14 +69,13 @@ export default Adapter.extend(BuildURLMixin, {
     if (link.related) {
       url = link.related;
     } else {
-      url = Ember.String.dasherize(relationship.key);
+      url = this.pathForRelationship(snapshot, relationship);
     }
 
     url = this.urlPrefix(url, this.buildURL(type, id, null, requestType));
 
     return this.ajax(url, 'GET');
   },
-
 
 
   createRecord: function(store, type, snapshot) {
@@ -106,6 +103,10 @@ export default Adapter.extend(BuildURLMixin, {
 
   pathForType: function(typeKey) {
     return Ember.String.dasherize(typeKey);
+  },
+
+  pathForRelationship: function(snapshot, relationship) {
+    return Ember.String.dasherize(relationship.key);
   },
 
 

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -1,0 +1,188 @@
+/**
+  @module ember-data
+*/
+
+import {
+  Adapter,
+  InvalidError
+} from "ember-data/system/adapter";
+
+import BuildURLMixin from "ember-data/adapters/build-url-mixin";
+
+var get = Ember.get;
+var forEach = Ember.ArrayPolyfills.forEach;
+
+/**
+  @class JSONAPIAdapter
+  @constructor
+  @namespace DS
+  @extends DS.Adapter
+*/
+export default Adapter.extend(BuildURLMixin, {
+  defaultSerializer: '-json-api',
+
+  coalesceFindRequests: false,
+
+  /**
+    @property host
+    @type {String}
+  */
+
+  /**
+    @property namespace
+    @type {String}
+  */
+
+  find: function(store, type, id, record) {
+    return this.ajax(this.buildURL(type.typeKey, id, record), 'GET');
+  },
+
+  findAll: function(store, type) {
+    return this.ajax(this.buildURL(type.typeKey), 'GET');
+  },
+
+  findMany: function(store, type, ids, records) {
+    var data = {
+      filter: {
+        id: ids.join(',')
+      }
+    };
+    return this.ajax(this.buildURL(type.typeKey, ids, records), 'GET', { data: data });
+  },
+
+  findQuery: function(store, type, query) {
+    return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
+  },
+
+
+
+  findBelongsTo: function(store, record, link, relationship) {
+    var url, id, type;
+
+    if (link.resource) {
+      url = link.resource;
+    } else {
+      id = get(record, 'id');
+      type = record.constructor.typeKey;
+      url = this.buildURL(type, id);
+    }
+
+    return this.ajax(url, 'GET');
+  },
+
+  findHasMany: function(store, record, link, relationship) {
+    var url; //, id, type, host;
+
+    if (link.resource) {
+      url = link.resource;
+    } else {
+      // TODO
+      return;
+    }
+
+    return this.ajax(url, 'GET');
+  },
+
+
+
+  createRecord: function(store, type, record) {
+    var serializer = store.serializerFor(type.typeKey);
+
+    var snapshot = record._createSnapshot();
+    var data = serializer.serialize(snapshot);
+
+    return this.ajax(this.buildURL(type.typeKey, null, record), "POST", { data: data });
+  },
+
+  updateRecord: function(store, type, record) {
+    var serializer = store.serializerFor(type.typeKey);
+
+    var snapshot = record._createSnapshot();
+    var data = serializer.serialize(snapshot, { includeId: true });
+
+    var id = get(record, 'id');
+
+    return this.ajax(this.buildURL(type.typeKey, id, record), "PUT", { data: data });
+  },
+
+  deleteRecord: function(store, type, record) {
+    var id = get(record, 'id');
+
+    return this.ajax(this.buildURL(type.typeKey, id, record), "DELETE");
+  },
+
+
+  pathForType: function(typeKey) {
+    return Ember.String.dasherize(typeKey);
+  },
+
+
+  ajax: function(url, type, options) {
+    var adapter = this;
+
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      var hash = adapter.ajaxOptions(url, type, options);
+
+      hash.success = function(json, textStatus, jqXHR) {
+        json = adapter.ajaxSuccess(jqXHR, json);
+        if (json instanceof InvalidError) {
+          Ember.run(null, reject, json);
+        } else {
+          Ember.run(null, resolve, json);
+        }
+      };
+
+      hash.error = function(jqXHR, textStatus, errorThrown) {
+        Ember.run(null, reject, adapter.ajaxError(jqXHR, jqXHR.responseText, errorThrown));
+      };
+
+      Ember.$.ajax(hash);
+    }, 'DS: JSONAPIAdapter#ajax ' + type + ' to ' + url);
+  },
+
+  ajaxOptions: function(url, type, options) {
+    var hash = options || {};
+    hash.url = url;
+    hash.type = type;
+    hash.dataType = 'json';
+    hash.context = this;
+
+    if (hash.data && type !== 'GET') {
+      hash.contentType = 'application/json; charset=utf-8';
+      hash.data = JSON.stringify(hash.data);
+    }
+
+    var headers = get(this, 'headers');
+    if (headers !== undefined) {
+      hash.beforeSend = function (xhr) {
+        forEach.call(Ember.keys(headers), function(key) {
+          xhr.setRequestHeader(key, headers[key]);
+        });
+      };
+    }
+
+    return hash;
+  },
+
+  ajaxError: function(jqXHR, responseText, errorThrown) {
+    var isObject = jqXHR !== null && typeof jqXHR === 'object';
+
+    if (isObject) {
+      jqXHR.then = null;
+      if (!jqXHR.errorThrown) {
+        if (typeof errorThrown === 'string') {
+          jqXHR.errorThrown = new Error(errorThrown);
+        } else {
+          jqXHR.errorThrown = errorThrown;
+        }
+      }
+    }
+
+    return jqXHR;
+  },
+
+  ajaxSuccess: function(jqXHR, jsonPayload) {
+    return jsonPayload;
+  }
+
+});

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -10,7 +10,6 @@ import {
 import BuildURLMixin from "ember-data/adapters/build-url-mixin";
 
 var get = Ember.get;
-var forEach = Ember.ArrayPolyfills.forEach;
 
 /**
   @class JSONAPIAdapter

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -33,48 +33,48 @@ export default Adapter.extend(BuildURLMixin, {
     @type {String}
   */
 
-  find: function(store, type, id, record) {
-    return this.ajax(this.buildURL(type.typeKey, id, record), 'GET');
+  find: function(store, type, id, snapshot) {
+    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'find'), 'GET');
   },
 
   findAll: function(store, type) {
-    return this.ajax(this.buildURL(type.typeKey), 'GET');
+    return this.ajax(this.buildURL(type.typeKey, null, null, 'findAll'), 'GET');
   },
 
-  findMany: function(store, type, ids, records) {
+  findMany: function(store, type, ids, snapshots) {
     var data = {
       filter: {
         id: ids.join(',')
       }
     };
-    return this.ajax(this.buildURL(type.typeKey, ids, records), 'GET', { data: data });
+    return this.ajax(this.buildURL(type.typeKey, ids, snapshots, 'findMany'), 'GET', { data: data });
   },
 
   findQuery: function(store, type, query) {
-    return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
+    return this.ajax(this.buildURL(type.typeKey, query, null, 'findQuery'), 'GET', { data: query });
   },
 
 
 
-  findBelongsTo: function(store, record, link, relationship) {
+  findBelongsTo: function(store, snapshot, link, relationship) {
     var url, id, type;
 
-    if (link.resource) {
-      url = link.resource;
+    if (link.related) {
+      url = link.related;
     } else {
-      id = get(record, 'id');
-      type = record.constructor.typeKey;
-      url = this.buildURL(type, id);
+      id = snapshot.id;
+      type = snapshot.typeKey;
+      url = this.buildURL(type, id, null, 'findBelongsTo');
     }
 
     return this.ajax(url, 'GET');
   },
 
-  findHasMany: function(store, record, link, relationship) {
+  findHasMany: function(store, snapshot, link, relationship) {
     var url; //, id, type, host;
 
-    if (link.resource) {
-      url = link.resource;
+    if (link.related) {
+      url = link.related;
     } else {
       // TODO
       return;
@@ -85,30 +85,26 @@ export default Adapter.extend(BuildURLMixin, {
 
 
 
-  createRecord: function(store, type, record) {
+  createRecord: function(store, type, snapshot) {
     var serializer = store.serializerFor(type.typeKey);
-
-    var snapshot = record._createSnapshot();
     var data = serializer.serialize(snapshot);
 
-    return this.ajax(this.buildURL(type.typeKey, null, record), "POST", { data: data });
+    return this.ajax(this.buildURL(type.typeKey, null, snapshot, 'createRecord'), 'POST', { data: data });
   },
 
-  updateRecord: function(store, type, record) {
+  updateRecord: function(store, type, snapshot) {
     var serializer = store.serializerFor(type.typeKey);
-
-    var snapshot = record._createSnapshot();
     var data = serializer.serialize(snapshot, { includeId: true });
 
-    var id = get(record, 'id');
+    var id = snapshot.id;
 
-    return this.ajax(this.buildURL(type.typeKey, id, record), "PUT", { data: data });
+    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'updateRecord'), 'PATCH', { data: data });
   },
 
-  deleteRecord: function(store, type, record) {
-    var id = get(record, 'id');
+  deleteRecord: function(store, type, snapshot) {
+    var id = snapshot.id;
 
-    return this.ajax(this.buildURL(type.typeKey, id, record), "DELETE");
+    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'deleteRecord'), 'DELETE');
   },
 
 

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -141,18 +141,14 @@ export default Adapter.extend(BuildURLMixin, {
     hash.context = this;
 
     if (hash.data && type !== 'GET') {
-      hash.contentType = 'application/json; charset=utf-8';
+      hash.contentType = 'application/vnd.api+json; charset=utf-8';
       hash.data = JSON.stringify(hash.data);
     }
 
-    var headers = get(this, 'headers');
-    if (headers !== undefined) {
-      hash.beforeSend = function (xhr) {
-        forEach.call(Ember.keys(headers), function(key) {
-          xhr.setRequestHeader(key, headers[key]);
-        });
-      };
-    }
+    var defaultHeaders = {
+      Accept: 'application/vnd.api+json; charset=utf-8'
+    };
+    hash.headers = Ember.merge(defaultHeaders, get(this, 'headers'));
 
     return hash;
   },

--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -57,28 +57,25 @@ export default Adapter.extend(BuildURLMixin, {
 
 
   findBelongsTo: function(store, snapshot, link, relationship) {
-    var url, id, type;
-
-    if (link.related) {
-      url = link.related;
-    } else {
-      id = snapshot.id;
-      type = snapshot.typeKey;
-      url = this.buildURL(type, id, null, 'findBelongsTo');
-    }
-
-    return this.ajax(url, 'GET');
+    return this._findRelationship(store, snapshot, link, relationship, 'findBelongsTo');
   },
 
   findHasMany: function(store, snapshot, link, relationship) {
-    var url; //, id, type, host;
+    return this._findRelationship(store, snapshot, link, relationship, 'findHasMany');
+  },
+
+  _findRelationship: function(store, snapshot, link, relationship, requestType) {
+    var url;
+    var type = snapshot.typeKey;
+    var id = snapshot.id;
 
     if (link.related) {
       url = link.related;
     } else {
-      // TODO
-      return;
+      url = Ember.String.dasherize(relationship.key);
     }
+
+    url = this.urlPrefix(url, this.buildURL(type, id, null, requestType));
 
     return this.ajax(url, 'GET');
   },

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -1,5 +1,5 @@
-import {JSONSerializer, RESTSerializer} from "ember-data/serializers";
-import {RESTAdapter} from "ember-data/adapters";
+import { JSONSerializer, JSONAPISerializer, RESTSerializer } from "ember-data/serializers";
+import { JSONAPIAdapter, RESTAdapter } from "ember-data/adapters";
 import ContainerProxy from "ember-data/system/container-proxy";
 import Store from "ember-data/system/store";
 
@@ -31,7 +31,9 @@ export default function initializeStore(registry, application) {
 
   // new go forward paths
   registry.register('serializer:-default', JSONSerializer);
+  registry.register('serializer:-json-api', JSONAPISerializer);
   registry.register('serializer:-rest', RESTSerializer);
+  registry.register('adapter:-json-api', JSONAPIAdapter);
   registry.register('adapter:-rest', RESTAdapter);
 
   // Eagerly generate the store so defaultStore is populated.

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -44,12 +44,16 @@ import {
 import ManyArray from "ember-data/system/many-array";
 import RecordArrayManager from "ember-data/system/record-array-manager";
 import {
-  RESTAdapter,
-  FixtureAdapter
+  FixtureAdapter,
+  JSONAPIAdapter,
+  RESTAdapter
 } from "ember-data/adapters";
 import BuildURLMixin from "ember-data/adapters/build-url-mixin";
-import JSONSerializer from "ember-data/serializers/json-serializer";
-import RESTSerializer from "ember-data/serializers/rest-serializer";
+import {
+  JSONSerializer,
+  JSONAPISerializer,
+  RESTSerializer
+} from "ember-data/serializers";
 import "ember-inflector";
 import EmbeddedRecordsMixin from "ember-data/serializers/embedded-records-mixin";
 import {
@@ -100,12 +104,15 @@ DS.ManyArray                   = ManyArray;
 
 DS.RecordArrayManager = RecordArrayManager;
 
-DS.RESTAdapter    = RESTAdapter;
-DS.BuildURLMixin  = BuildURLMixin;
-DS.FixtureAdapter = FixtureAdapter;
+DS.BuildURLMixin = BuildURLMixin;
 
-DS.RESTSerializer = RESTSerializer;
-DS.JSONSerializer = JSONSerializer;
+DS.FixtureAdapter = FixtureAdapter;
+DS.JSONAPIAdapter = JSONAPIAdapter;
+DS.RESTAdapter    = RESTAdapter;
+
+DS.JSONSerializer    = JSONSerializer;
+DS.JSONAPISerializer = JSONAPISerializer;
+DS.RESTSerializer    = RESTSerializer;
 
 DS.Transform       = Transform;
 DS.DateTransform   = DateTransform;

--- a/packages/ember-data/lib/serializers.js
+++ b/packages/ember-data/lib/serializers.js
@@ -1,7 +1,9 @@
 import JSONSerializer from "ember-data/serializers/json-serializer";
+import JSONAPISerializer from "ember-data/serializers/json-api-serializer";
 import RESTSerializer from "ember-data/serializers/rest-serializer";
 
 export {
   JSONSerializer,
+  JSONAPISerializer,
   RESTSerializer
 };

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -291,5 +291,20 @@ export default Serializer.extend({
       var transform = this.transformFor(type);
       hash[key] = transform.deserialize(hash[key]);
     }, this);
+  },
+
+  // HELPERS
+
+  /**
+   @method transformFor
+   @private
+   @param {String} attributeType
+   @param {Boolean} skipAssertion
+   @return {DS.Transform} transform
+  */
+  transformFor: function(attributeType, skipAssertion) {
+    var transform = this.container.lookup('transform:' + attributeType);
+    Ember.assert("Unable to find transform for '" + attributeType + "'", skipAssertion || !!transform);
+    return transform;
   }
 });

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -25,7 +25,7 @@ export default Serializer.extend({
   },
 
   normalizeTypeKey: function(typeKey) {
-    return Ember.String.camelize(typeKey);
+    return Ember.String.dasherize(typeKey);
   },
 
   serializeTypeKey: function(typeKey) {

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -107,6 +107,12 @@ export default Serializer.extend({
   },
 
 
+  extractErrors: function(store, type, payload, id) {
+    if (!payload.errors) { return payload; }
+
+    return payload.errors;
+  },
+
 
   serialize: function(snapshot, options) {
     var json = {};

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -1,0 +1,294 @@
+/**
+  @module ember-data
+*/
+
+import Serializer from "ember-data/system/serializer";
+
+var copy = Ember.copy;
+var get = Ember.get;
+var forEach = Ember.ArrayPolyfills.forEach;
+var map = Ember.ArrayPolyfills.map;
+
+/**
+  @class JSONAPISerializer
+  @namespace DS
+  @extends DS.Serializer
+*/
+export default Serializer.extend({
+
+  keyForAttribute: function(key) {
+    return Ember.String.dasherize(key);
+  },
+
+  keyForRelationship: function(key, kind) {
+    return Ember.String.dasherize(key);
+  },
+
+  normalizeTypeKey: function(typeKey) {
+    return Ember.String.camelize(typeKey);
+  },
+
+  serializeTypeKey: function(typeKey) {
+    return Ember.String.dasherize(typeKey);
+  },
+
+
+
+  extract: function(store, type, payload, id, requestType) {
+    if (!payload.data) { return; }
+
+    var dataType = Ember.typeOf(payload.data);
+
+    if (dataType === 'object') {
+      return this.extractSingle(store, payload, id);
+    } else if (dataType === 'array') {
+      store.setMetadataFor(type, payload.meta || {});
+      return this.extractArray(store, payload);
+    }
+  },
+
+  extractSingle: function(store, payload, id) {
+    var data;
+
+    this.extractIncluded(store, payload.included);
+
+    data = this.extractData(store, get(payload, 'data'));
+
+    return data;
+  },
+
+  extractArray: function(store, payload) {
+    var data;
+
+    this.extractIncluded(store, payload.included);
+
+    data = map.call(payload.data, function(item) {
+      return this.extractData(store, item);
+    }, this);
+
+    return data;
+  },
+
+  extractData: function(store, data) {
+    var type, typeName, typeSerializer;
+
+    if (!data) { return; }
+
+    typeName = this.normalizeTypeKey(data.type);
+
+    Ember.assert('No model was found for model name "' + typeName + '"', store.modelFactoryFor(typeName));
+
+    type = store.modelFor(typeName);
+    typeSerializer = store.serializerFor(type);
+
+    return typeSerializer.normalize(type, data);
+  },
+
+  extractIncluded: function(store, included) {
+    var type, typeName, typeSerializer, hash;
+
+    if (!included) { return; }
+
+    forEach.call(included, function(data) {
+      typeName = this.normalizeTypeKey(data.type);
+
+      if (!store.modelFactoryFor(typeName)) {
+        Ember.warn('No model was found for model name "' + typeName + '"', false);
+        return;
+      }
+
+      type = store.modelFor(typeName);
+      typeSerializer = store.serializerFor(type);
+
+      hash = typeSerializer.normalize(type, data);
+      store.push(typeName, hash);
+    }, this);
+  },
+
+
+
+  serialize: function(snapshot, options) {
+    var json = {};
+
+    json['type'] = this.serializeTypeKey(snapshot.typeKey);
+
+    if (options && options.includeId) {
+      json['id'] = snapshot.id;
+    }
+
+    snapshot.eachAttribute(function(key, attribute) {
+      this.serializeAttribute(snapshot, json, key, attribute);
+    }, this);
+
+    snapshot.eachRelationship(function(key, relationship) {
+      if (relationship.kind === 'belongsTo') {
+        this.serializeBelongsTo(snapshot, json, relationship);
+      } else if (relationship.kind === 'hasMany') {
+        this.serializeHasMany(snapshot, json, relationship);
+      }
+    }, this);
+
+    json = { data: json };
+
+    return json;
+  },
+
+  serializeAttribute: function(snapshot, json, key, attribute) {
+    var value = snapshot.attr(key);
+    var type = attribute.type;
+
+    if (type) {
+      var transform = this.transformFor(type);
+      value = transform.serialize(value);
+    }
+
+    var payloadKey = this.keyForAttribute(key);
+    json[payloadKey] = value;
+  },
+
+  serializeBelongsTo: function(snapshot, json, relationship) {
+    var key = relationship.key;
+    var belongsTo = snapshot.belongsTo(key);
+
+    var links = json['links'] = json['links'] || {};
+
+    var payloadKey = this.keyForRelationship(key, 'belongsTo');
+
+    if (Ember.isNone(belongsTo)) {
+      links[payloadKey] = { id: null };
+    } else {
+      links[payloadKey] = {
+        type: this.serializeTypeKey(belongsTo.typeKey),
+        id: belongsTo.id
+      };
+    }
+  },
+
+  serializeHasMany: function(snapshot, json, relationship) {
+    var key = relationship.key;
+    var hasMany = snapshot.hasMany(key);
+
+    var links = json['links'] = json['links'] || {};
+
+    var payloadKey = this.keyForRelationship(key, 'hasMany');
+
+    if (hasMany.length === 0) {
+      links[payloadKey] = { ids: [] };
+    } else {
+
+      // TODO: if all items in hasMany is of the same type, provide
+      // { type: "type", ids: [..] } instead of { data: [...] }
+
+      var data = [];
+      for (var i = 0; i < hasMany.length; i++) {
+        data.push({
+          type: this.serializeTypeKey(hasMany[i].typeKey),
+          id: hasMany[i].id
+        });
+      }
+      links[payloadKey] = { data: data };
+    }
+  },
+
+
+
+  normalize: function(type, data) {
+    var hash = copy(data);
+
+    this.normalizeAttributes(type, hash);
+    this.normalizeRelationships(type, hash);
+    this.normalizeLinks(hash);
+    this.applyTransforms(type, hash);
+
+    return hash;
+  },
+
+  normalizeAttributes: function(type, hash) {
+    var payloadKey;
+
+    type.eachAttribute(function(key) {
+      payloadKey = this.keyForAttribute(key);
+
+      if (key === payloadKey) { return; }
+      if (!hash.hasOwnProperty(payloadKey)) { return; }
+
+      hash[key] = hash[payloadKey];
+      delete hash[payloadKey];
+    }, this);
+  },
+
+  normalizeRelationships: function(type, hash) {
+    var payloadKey, link;
+
+    if (!hash.links) { return; }
+
+    type.eachRelationship(function(key, relationship) {
+      payloadKey = this.keyForRelationship(key, relationship.kind);
+
+      if (hash.links[payloadKey]) {
+        link = hash.links[payloadKey];
+
+        if (relationship.kind === 'belongsTo' && link.id) {
+
+          hash[key] = { id: link.id, type: this.normalizeTypeKey(link.type) };
+          delete hash.links[payloadKey];
+
+        } else if (relationship.kind === 'hasMany') {
+
+          if (link.ids) {
+
+            hash[key] = map.call(link.ids, function(id) {
+              return { id: id, type: this.normalizeTypeKey(link.type) };
+            }, this);
+            delete hash.links[payloadKey];
+
+          } else if (link.data) {
+
+            hash[key] = map.call(link.data, function(item) {
+              return { id: item.id, type: this.normalizeTypeKey(item.type) };
+            }, this);
+            delete hash.links[payloadKey];
+
+          }
+        }
+      }
+    }, this);
+  },
+
+  normalizeLinks: function(hash) {
+    var links = hash.links;
+
+    if (!links) { return; }
+
+    for (var key in links) {
+      links[key] = this.normalizeLink(links[key]);
+    }
+  },
+
+  normalizeLink: function(link) {
+    var normalizedLink = {};
+
+    if (Ember.typeOf(link) === 'string') {
+      normalizedLink = {
+        self: null,
+        resource: link
+      };
+    } else {
+      normalizedLink = {
+        self: link.self || null,
+        resource: link.resource || null
+      };
+    }
+
+    return normalizedLink;
+  },
+
+  applyTransforms: function(type, hash) {
+    type.eachTransformedAttribute(function applyTransform(key, type) {
+      if (!hash.hasOwnProperty(key)) { return; }
+
+      var transform = this.transformFor(type);
+      hash[key] = transform.deserialize(hash[key]);
+    }, this);
+  }
+});

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -205,7 +205,6 @@ Relationship.prototype = {
 
   updateLink: function(link) {
     Ember.warn("You have pushed a record of type '" + this.record.constructor.typeKey + "' with '" + this.key + "' as a link, but the association is not an async relationship.", this.isAsync);
-    Ember.assert("You have pushed a record of type '" + this.record.constructor.typeKey + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
     if (link !== this.link) {
       this.link = link;
       this.linkPromise = null;

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -123,22 +123,22 @@ test('find all records with sideloaded relationships', function() {
       title: "Ember.js rocks",
       links: {
         author: {
-          type: "user",
-          id: "3"
+          linkage: { type: "user", id: "3" }
         }
       }
     }, {
       type: "post",
       id: "2",
-      title: "Tompster rules",
+      title: "Tomster rules",
       links: {
         author: {
-          type: "user",
-          id: "3"
+          linkage: { type: "user", id: "3" }
         },
         comments: {
-          type: "comment",
-          ids: ["4", "5"]
+          linkage: [
+            { type: "comment", id: "4" },
+            { type: "comment", id: "5" }
+          ]
         }
       }
     }],
@@ -164,7 +164,7 @@ test('find all records with sideloaded relationships', function() {
 
       equal(posts.get('length'), '2');
       equal(posts.get('firstObject.title'), 'Ember.js rocks');
-      equal(posts.get('lastObject.title'), 'Tompster rules');
+      equal(posts.get('lastObject.title'), 'Tomster rules');
 
       equal(posts.get('firstObject.author.firstName'), 'Yehuda');
       equal(posts.get('lastObject.author.lastName'), 'Katz');
@@ -239,7 +239,7 @@ test('find a single record with belongsTo link as string', function() {
   });
 });
 
-test('find a single record with belongsTo link as object { resource }', function() {
+test('find a single record with belongsTo link as object { related }', function() {
   expect(7);
 
   ajaxResponse([{
@@ -249,7 +249,7 @@ test('find a single record with belongsTo link as object { resource }', function
       title: "Ember.js rocks",
       links: {
         author: {
-          resource: "http://example.com/user/2"
+          related: "http://example.com/user/2"
         }
       }
     }
@@ -280,7 +280,7 @@ test('find a single record with belongsTo link as object { resource }', function
   });
 });
 
-test('find a single record with belongsTo link as object { type, id }', function() {
+test('find a single record with belongsTo link as object { linkage }', function() {
   expect(7);
 
   ajaxResponse([{
@@ -290,8 +290,7 @@ test('find a single record with belongsTo link as object { type, id }', function
       title: "Ember.js rocks",
       links: {
         author: {
-          type: "user",
-          id: "2"
+          linkage: { type: "user", id: "2" }
         }
       }
     }
@@ -322,7 +321,7 @@ test('find a single record with belongsTo link as object { type, id }', function
   });
 });
 
-test('find a single record with belongsTo link as object { type, id } (polymorphic)', function() {
+test('find a single record with belongsTo link as object { linkage } (polymorphic)', function() {
   expect(8);
 
   ajaxResponse([{
@@ -333,8 +332,7 @@ test('find a single record with belongsTo link as object { type, id } (polymorph
       'last-name': "Katz",
       links: {
         company: {
-          type: "development-shop",
-          id: "2"
+          linkage: { type: "development-shop", id: "2" }
         }
       }
     }
@@ -366,7 +364,7 @@ test('find a single record with belongsTo link as object { type, id } (polymorph
   });
 });
 
-test('find a single record with sideloaded belongsTo link as object { type, id }', function() {
+test('find a single record with sideloaded belongsTo link as object { linkage }', function() {
   expect(7);
 
   ajaxResponse([{
@@ -376,8 +374,7 @@ test('find a single record with sideloaded belongsTo link as object { type, id }
       title: "Ember.js rocks",
       links: {
         author: {
-          type: "user",
-          id: "2"
+          linkage: { type: "user", id: "2" }
         }
       }
     },
@@ -450,7 +447,51 @@ test('find a single record with hasMany link as string', function() {
   });
 });
 
-test('find a single record with hasMany link as object { type, ids }', function() {
+test('find a single record with hasMany link as object { related }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        comments: {
+          related: "http://example.com/post/1/comments"
+        }
+      }
+    }
+  }, {
+    data: [{
+      type: "comment",
+      id: "2",
+      text: "This is the first comment"
+    }, {
+      type: "comment",
+      id: "3",
+      text: "This is the second comment"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('comments').then(function(comments) {
+        equal(passedUrl[1], 'http://example.com/post/1/comments');
+
+        equal(comments.get('length'), 2);
+        equal(comments.get('firstObject.text'), 'This is the first comment');
+        equal(comments.get('lastObject.text'), 'This is the second comment');
+      });
+    });
+  });
+});
+
+test('find a single record with hasMany link as object { linkage }', function() {
   expect(8);
 
   ajaxResponse([{
@@ -460,8 +501,10 @@ test('find a single record with hasMany link as object { type, ids }', function(
       title: "Ember.js rocks",
       links: {
         comments: {
-          type: "comment",
-          ids: ["2", "3"]
+          linkage: [
+            { type: "comment", id: "2" },
+            { type: "comment", id: "3" }
+          ]
         }
       }
     }
@@ -498,7 +541,7 @@ test('find a single record with hasMany link as object { type, ids }', function(
   });
 });
 
-test('find a single record with hasMany link as object { data }  (polymorphic)', function() {
+test('find a single record with hasMany link as object { linkage }  (polymorphic)', function() {
   expect(9);
 
   ajaxResponse([{
@@ -509,13 +552,10 @@ test('find a single record with hasMany link as object { data }  (polymorphic)',
       'last-name': "Katz",
       links: {
         handles: {
-          data: [{
-            "type": "github-handle",
-            "id": "2"
-          }, {
-            "type": "twitter-handle",
-            "id": "3"
-          }]
+          linkage: [
+            { type: "github-handle", id: "2" },
+            { type: "twitter-handle", id: "3" }
+          ]
         }
       }
     }
@@ -553,7 +593,7 @@ test('find a single record with hasMany link as object { data }  (polymorphic)',
   });
 });
 
-test('find a single record with sideloaded hasMany link as object { type, ids }', function() {
+test('find a single record with sideloaded hasMany link as object { linkage }', function() {
   expect(7);
 
   ajaxResponse([{
@@ -563,8 +603,10 @@ test('find a single record with sideloaded hasMany link as object { type, ids }'
       title: "Ember.js rocks",
       links: {
         comments: {
-          type: "comment",
-          ids: ["2", "3"]
+          linkage: [
+            { type: "comment", id: "2" },
+            { type: "comment", id: "3" }
+          ]
         }
       }
     },
@@ -597,7 +639,7 @@ test('find a single record with sideloaded hasMany link as object { type, ids }'
   });
 });
 
-test('find a single record with sideloaded hasMany link as object { data } (polymorphic)', function() {
+test('find a single record with sideloaded hasMany link as object { linkage } (polymorphic)', function() {
   expect(8);
 
   ajaxResponse([{
@@ -608,13 +650,10 @@ test('find a single record with sideloaded hasMany link as object { data } (poly
       'last-name': "Katz",
       links: {
         handles: {
-          data: [{
-            "type": "github-handle",
-            "id": "2"
-          }, {
-            "type": "twitter-handle",
-            "id": "3"
-          }]
+          linkage: [
+            { type: "github-handle", id: "2" },
+            { type: "twitter-handle", id: "3" }
+          ]
         }
       }
     },
@@ -693,9 +732,11 @@ test('create record', function() {
               type: "post",
               title: "Ember.js rocks",
               links: {
-                author: { type: "user", id: "1" },
+                author: {
+                  linkage: { type: "user", id: "1" }
+                },
                 comments: {
-                  data: [
+                  linkage: [
                     { type: "comment", id: "2" },
                     { type: "comment", id: "3" }
                   ]
@@ -750,7 +791,7 @@ test('update record', function() {
 
       post.save().then(function() {
         equal(passedUrl[0], '/post/4');
-        equal(passedVerb[0], 'PUT');
+        equal(passedVerb[0], 'PATCH');
         deepEqual(passedHash[0], {
           data: {
             data : {
@@ -758,9 +799,11 @@ test('update record', function() {
               id: "4",
               title: "Ember.js rocks",
               links: {
-                author: { type: "user", id: "1" },
+                author: {
+                  linkage: { type: "user", id: "1" }
+                },
                 comments: {
-                  data: [
+                  linkage: [
                     { type: "comment", id: "2" },
                     { type: "comment", id: "3" }
                   ]

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -1,3 +1,4 @@
+/* global mockSerializerTransformFor */
 var env, store, adapter;
 var run = Ember.run;
 var passedUrl, passedVerb, passedHash;
@@ -52,6 +53,9 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', {
 
     env = setupStore({
       adapter: DS.JSONAPIAdapter,
+      jsonApiSerializer: DS.JSONAPISerializer.extend({
+        transformFor: mockSerializerTransformFor()
+      }),
 
       user: User,
       post: Post,

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -1,0 +1,776 @@
+var env, store, adapter;
+var run = Ember.run;
+var passedUrl, passedVerb, passedHash;
+
+var User, Post, Comment, Handle, GithubHandle, TwitterHandle, Company, DevelopmentShop, DesignStudio;
+
+module('integration/adapter/json-api-adapter - JSONAPIAdapter', {
+  setup: function() {
+    User = DS.Model.extend({
+      firstName: DS.attr('string'),
+      lastName: DS.attr('string'),
+      posts: DS.hasMany('post', { async: true }),
+      handles: DS.hasMany('handle', { async: true, polymorphic: true }),
+      company: DS.belongsTo('company', { async: true, polymorphic: true })
+    });
+
+    Post = DS.Model.extend({
+      title: DS.attr('string'),
+      author: DS.belongsTo('user', { async: true }),
+      comments: DS.hasMany('comment', { async: true })
+    });
+
+    Comment = DS.Model.extend({
+      text: DS.attr('string'),
+      post: DS.belongsTo('post', { async: true })
+    });
+
+    Handle = DS.Model.extend({
+      user: DS.belongsTo('post', { async: true })
+    });
+
+    GithubHandle = Handle.extend({
+      username: DS.attr('string')
+    });
+
+    TwitterHandle = Handle.extend({
+      nickname: DS.attr('string')
+    });
+
+    Company = DS.Model.extend({
+      name: DS.attr('string'),
+      employees: DS.hasMany('user', { async: true })
+    });
+
+    DevelopmentShop = Company.extend({
+      coffee: DS.attr('boolean')
+    });
+
+    DesignStudio = Company.extend({
+      hipsters: DS.attr('number')
+    });
+
+    env = setupStore({
+      adapter: DS.JSONAPIAdapter,
+
+      user: User,
+      post: Post,
+      comment: Comment,
+      handle: Handle,
+      githubHandle: GithubHandle,
+      twitterHandle: TwitterHandle,
+      company: Company,
+      developmentShop: DevelopmentShop,
+      designStudio: DesignStudio
+    });
+
+    store = env.store;
+    adapter = env.adapter;
+  },
+
+  teardown: function() {
+    run(env.store, 'destroy');
+  }
+});
+
+function ajaxResponse(responses) {
+  var counter = 0;
+  var index;
+
+  passedUrl = [];
+  passedVerb = [];
+  passedHash = [];
+
+  adapter.ajax = function(url, verb, hash) {
+    index = counter++;
+
+    passedUrl[index] = url;
+    passedVerb[index] = verb;
+    passedHash[index] = hash;
+
+    return run(Ember.RSVP, 'resolve', responses[index]);
+  };
+}
+
+test('find a single record', function() {
+  expect(3);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks"
+    }
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+    });
+  });
+});
+
+test('find all records with sideloaded relationships', function() {
+  expect(9);
+
+  ajaxResponse([{
+    data: [{
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        author: {
+          type: "user",
+          id: "3"
+        }
+      }
+    }, {
+      type: "post",
+      id: "2",
+      title: "Tompster rules",
+      links: {
+        author: {
+          type: "user",
+          id: "3"
+        },
+        comments: {
+          type: "comment",
+          ids: ["4", "5"]
+        }
+      }
+    }],
+    included: [{
+      type: "user",
+      id: "3",
+      'first-name': "Yehuda",
+      'last-name': "Katz"
+    }, {
+      type: "comment",
+      id: "4",
+      text: "This is the first comment"
+    }, {
+      type: "comment",
+      id: "5",
+      text: "This is the second comment"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post').then(function(posts) {
+      equal(passedUrl[0], '/post');
+
+      equal(posts.get('length'), '2');
+      equal(posts.get('firstObject.title'), 'Ember.js rocks');
+      equal(posts.get('lastObject.title'), 'Tompster rules');
+
+      equal(posts.get('firstObject.author.firstName'), 'Yehuda');
+      equal(posts.get('lastObject.author.lastName'), 'Katz');
+
+      equal(posts.get('firstObject.comments.length'), 0);
+
+      equal(posts.get('lastObject.comments.firstObject.text'), 'This is the first comment');
+      equal(posts.get('lastObject.comments.lastObject.text'), 'This is the second comment');
+    });
+  });
+});
+
+test('find many records', function() {
+  expect(4);
+
+  ajaxResponse([{
+    data: [{
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post', { filter: { id: 1 } }).then(function(posts) {
+      equal(passedUrl[0], '/post');
+      deepEqual(passedHash[0], { data: { filter: { id: 1 } } });
+
+      equal(posts.get('length'), '1');
+      equal(posts.get('firstObject.title'), 'Ember.js rocks');
+    });
+  });
+});
+
+test('find a single record with belongsTo link as string', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        author: "http://example.com/post/1/author"
+      }
+    }
+  }, {
+    data: {
+      type: "user",
+      id: "2",
+      'first-name': 'Yehuda',
+      'last-name': 'Katz'
+    }
+  }]);
+
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('author').then(function(author) {
+        equal(passedUrl[1], 'http://example.com/post/1/author');
+
+        equal(author.get('id'), '2');
+        equal(author.get('firstName'), 'Yehuda');
+        equal(author.get('lastName'), 'Katz');
+      });
+    });
+  });
+});
+
+test('find a single record with belongsTo link as object { resource }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        author: {
+          resource: "http://example.com/user/2"
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "user",
+      id: "2",
+      'first-name': 'Yehuda',
+      'last-name': 'Katz'
+    }
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('author').then(function(author) {
+        equal(passedUrl[1], 'http://example.com/user/2');
+
+        equal(author.get('id'), '2');
+        equal(author.get('firstName'), 'Yehuda');
+        equal(author.get('lastName'), 'Katz');
+      });
+    });
+  });
+});
+
+test('find a single record with belongsTo link as object { type, id }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        author: {
+          type: "user",
+          id: "2"
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "user",
+      id: "2",
+      'first-name': 'Yehuda',
+      'last-name': 'Katz'
+    }
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('author').then(function(author) {
+        equal(passedUrl[1], '/user/2');
+
+        equal(author.get('id'), '2');
+        equal(author.get('firstName'), 'Yehuda');
+        equal(author.get('lastName'), 'Katz');
+      });
+    });
+  });
+});
+
+test('find a single record with belongsTo link as object { type, id } (polymorphic)', function() {
+  expect(8);
+
+  ajaxResponse([{
+    data: {
+      type: "user",
+      id: "1",
+      'first-name': "Yehuda",
+      'last-name': "Katz",
+      links: {
+        company: {
+          type: "development-shop",
+          id: "2"
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "development-shop",
+      id: "2",
+      name: 'Tilde',
+      coffee: true
+    }
+  }]);
+
+  run(function() {
+    store.find('user', 1).then(function(user) {
+      equal(passedUrl[0], '/user/1');
+
+      equal(user.get('id'), '1');
+      equal(user.get('firstName'), 'Yehuda');
+      equal(user.get('lastName'), 'Katz');
+
+      user.get('company').then(function(company) {
+        equal(passedUrl[1], '/development-shop/2');
+
+        equal(company.get('id'), '2');
+        equal(company.get('name'), 'Tilde');
+        equal(company.get('coffee'), true);
+      });
+    });
+  });
+});
+
+test('find a single record with sideloaded belongsTo link as object { type, id }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        author: {
+          type: "user",
+          id: "2"
+        }
+      }
+    },
+    included: [{
+      type: "user",
+      id: "2",
+      'first-name': 'Yehuda',
+      'last-name': 'Katz'
+    }]
+  }]);
+
+  run(function() {
+
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('author').then(function(author) {
+        equal(passedUrl.length, 1);
+
+        equal(author.get('id'), '2');
+        equal(author.get('firstName'), 'Yehuda');
+        equal(author.get('lastName'), 'Katz');
+      });
+    });
+  });
+});
+
+test('find a single record with hasMany link as string', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        comments: "http://example.com/post/1/comments"
+      }
+    }
+  }, {
+    data: [{
+      type: "comment",
+      id: "2",
+      text: "This is the first comment"
+    }, {
+      type: "comment",
+      id: "3",
+      text: "This is the second comment"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('comments').then(function(comments) {
+        equal(passedUrl[1], 'http://example.com/post/1/comments');
+
+        equal(comments.get('length'), 2);
+        equal(comments.get('firstObject.text'), 'This is the first comment');
+        equal(comments.get('lastObject.text'), 'This is the second comment');
+      });
+    });
+  });
+});
+
+test('find a single record with hasMany link as object { type, ids }', function() {
+  expect(8);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        comments: {
+          type: "comment",
+          ids: ["2", "3"]
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "comment",
+      id: "2",
+      text: "This is the first comment"
+    }
+  }, {
+    data: {
+      type: "comment",
+      id: "3",
+      text: "This is the second comment"
+    }
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('comments').then(function(comments) {
+        equal(passedUrl[1], '/comment/2');
+        equal(passedUrl[2], '/comment/3');
+
+        equal(comments.get('length'), 2);
+        equal(comments.get('firstObject.text'), 'This is the first comment');
+        equal(comments.get('lastObject.text'), 'This is the second comment');
+      });
+    });
+  });
+});
+
+test('find a single record with hasMany link as object { data }  (polymorphic)', function() {
+  expect(9);
+
+  ajaxResponse([{
+    data: {
+      type: "user",
+      id: "1",
+      'first-name': "Yehuda",
+      'last-name': "Katz",
+      links: {
+        handles: {
+          data: [{
+            "type": "github-handle",
+            "id": "2"
+          }, {
+            "type": "twitter-handle",
+            "id": "3"
+          }]
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "github-handle",
+      id: "2",
+      username: "wycats"
+    }
+  }, {
+    data: {
+      type: "twitter-handle",
+      id: "3",
+      nickname: "@wycats"
+    }
+  }]);
+
+  run(function() {
+    store.find('user', 1).then(function(user) {
+      equal(passedUrl[0], '/user/1');
+
+      equal(user.get('id'), '1');
+      equal(user.get('firstName'), 'Yehuda');
+      equal(user.get('lastName'), 'Katz');
+
+      user.get('handles').then(function(handles) {
+        equal(passedUrl[1], '/github-handle/2');
+        equal(passedUrl[2], '/twitter-handle/3');
+
+        equal(handles.get('length'), 2);
+        equal(handles.get('firstObject.username'), 'wycats');
+        equal(handles.get('lastObject.nickname'), '@wycats');
+      });
+    });
+  });
+});
+
+test('find a single record with sideloaded hasMany link as object { type, ids }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        comments: {
+          type: "comment",
+          ids: ["2", "3"]
+        }
+      }
+    },
+    included: [{
+      type: "comment",
+      id: "2",
+      text: "This is the first comment"
+    }, {
+      type: "comment",
+      id: "3",
+      text: "This is the second comment"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('comments').then(function(comments) {
+        equal(passedUrl.length, 1);
+
+        equal(comments.get('length'), 2);
+        equal(comments.get('firstObject.text'), 'This is the first comment');
+        equal(comments.get('lastObject.text'), 'This is the second comment');
+      });
+    });
+  });
+});
+
+test('find a single record with sideloaded hasMany link as object { data } (polymorphic)', function() {
+  expect(8);
+
+  ajaxResponse([{
+    data: {
+      type: "user",
+      id: "1",
+      'first-name': "Yehuda",
+      'last-name': "Katz",
+      links: {
+        handles: {
+          data: [{
+            "type": "github-handle",
+            "id": "2"
+          }, {
+            "type": "twitter-handle",
+            "id": "3"
+          }]
+        }
+      }
+    },
+    included: [{
+      type: "github-handle",
+      id: "2",
+      username: "wycats"
+    }, {
+      type: "twitter-handle",
+      id: "3",
+      nickname: "@wycats"
+    }]
+  }]);
+
+  run(function() {
+    store.find('user', 1).then(function(user) {
+      equal(passedUrl[0], '/user/1');
+
+      equal(user.get('id'), '1');
+      equal(user.get('firstName'), 'Yehuda');
+      equal(user.get('lastName'), 'Katz');
+
+      user.get('handles').then(function(handles) {
+        equal(passedUrl.length, 1);
+
+        equal(handles.get('length'), 2);
+        equal(handles.get('firstObject.username'), 'wycats');
+        equal(handles.get('lastObject.nickname'), '@wycats');
+      });
+    });
+  });
+});
+
+test('create record', function() {
+  expect(3);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "4"
+    }
+  }]);
+
+  run(function() {
+    var user = store.push('user', store.normalize('user', {
+      id: 1,
+      firstName: "Yehuda",
+      lastName: "Katz"
+    }));
+
+    var comment1 = store.push('comment', store.normalize('comment', {
+      id: 2,
+      text: "This is the first comment comment"
+    }));
+
+    var comment2 = store.push('comment', store.normalize('comment', {
+      id: 3,
+      text: "This is the second comment"
+    }));
+
+    var post = store.createRecord('post', {
+      title: 'Ember.js rocks',
+      author: user
+    });
+
+    post.get('comments').then(function(comments) {
+      comments.addObject(comment1);
+      comments.addObject(comment2);
+
+      post.save().then(function() {
+        equal(passedUrl[0], '/post');
+        equal(passedVerb[0], 'POST');
+        deepEqual(passedHash[0], {
+          data: {
+            data : {
+              type: "post",
+              title: "Ember.js rocks",
+              links: {
+                author: { type: "user", id: "1" },
+                comments: {
+                  data: [
+                    { type: "comment", id: "2" },
+                    { type: "comment", id: "3" }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      });
+    });
+  });
+});
+
+test('update record', function() {
+  expect(3);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "4"
+    }
+  }]);
+
+  run(function() {
+    var user = store.push('user', store.normalize('user', {
+      id: 1,
+      firstName: "Yehuda",
+      lastName: "Katz"
+    }));
+
+    var comment1 = store.push('comment', store.normalize('comment', {
+      id: 2,
+      text: "This is the first comment comment"
+    }));
+
+    var comment2 = store.push('comment', store.normalize('comment', {
+      id: 3,
+      text: "This is the second comment"
+    }));
+
+    var post = store.push('post', store.normalize('post', {
+      id: 4,
+      title: 'Original title'
+    }));
+
+    post.set('title', 'Ember.js rocks');
+    post.set('author', user);
+
+    post.get('comments').then(function(comments) {
+      comments.addObject(comment1);
+      comments.addObject(comment2);
+
+      post.save().then(function() {
+        equal(passedUrl[0], '/post/4');
+        equal(passedVerb[0], 'PUT');
+        deepEqual(passedHash[0], {
+          data: {
+            data : {
+              type: "post",
+              id: "4",
+              title: "Ember.js rocks",
+              links: {
+                author: { type: "user", id: "1" },
+                comments: {
+                  data: [
+                    { type: "comment", id: "2" },
+                    { type: "comment", id: "3" }
+                  ]
+                }
+              }
+            }
+          }
+        });
+      });
+
+    });
+  });
+});

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -57,11 +57,11 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', {
       post: Post,
       comment: Comment,
       handle: Handle,
-      githubHandle: GithubHandle,
-      twitterHandle: TwitterHandle,
+      'github-handle': GithubHandle,
+      'twitter-handle': TwitterHandle,
       company: Company,
-      developmentShop: DevelopmentShop,
-      designStudio: DesignStudio
+      'development-shop': DevelopmentShop,
+      'design-studio': DesignStudio
     });
 
     store = env.store;
@@ -230,6 +230,48 @@ test('find a single record with belongsTo link as string', function() {
 
       post.get('author').then(function(author) {
         equal(passedUrl[1], 'http://example.com/post/1/author');
+
+        equal(author.get('id'), '2');
+        equal(author.get('firstName'), 'Yehuda');
+        equal(author.get('lastName'), 'Katz');
+      });
+    });
+  });
+});
+
+test('find a single record with belongsTo link as object { self }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      author: "2",
+      links: {
+        author: {
+          self: "dummy"
+        }
+      }
+    }
+  }, {
+    data: {
+      type: "user",
+      id: "2",
+      'first-name': 'Yehuda',
+      'last-name': 'Katz'
+    }
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('author').then(function(author) {
+        equal(passedUrl[1], '/post/1/author');
 
         equal(author.get('id'), '2');
         equal(author.get('firstName'), 'Yehuda');
@@ -438,6 +480,50 @@ test('find a single record with hasMany link as string', function() {
 
       post.get('comments').then(function(comments) {
         equal(passedUrl[1], 'http://example.com/post/1/comments');
+
+        equal(comments.get('length'), 2);
+        equal(comments.get('firstObject.text'), 'This is the first comment');
+        equal(comments.get('lastObject.text'), 'This is the second comment');
+      });
+    });
+  });
+});
+
+test('find a single record with hasMany link as object { self }', function() {
+  expect(7);
+
+  ajaxResponse([{
+    data: {
+      type: "post",
+      id: "1",
+      title: "Ember.js rocks",
+      links: {
+        comments: {
+          self: "dummy"
+        }
+      }
+    }
+  }, {
+    data: [{
+      type: "comment",
+      id: "2",
+      text: "This is the first comment"
+    }, {
+      type: "comment",
+      id: "3",
+      text: "This is the second comment"
+    }]
+  }]);
+
+  run(function() {
+    store.find('post', 1).then(function(post) {
+      equal(passedUrl[0], '/post/1');
+
+      equal(post.get('id'), '1');
+      equal(post.get('title'), 'Ember.js rocks');
+
+      post.get('comments').then(function(comments) {
+        equal(passedUrl[1], '/post/1/comments');
 
         equal(comments.get('length'), 2);
         equal(comments.get('firstObject.text'), 'This is the first comment');

--- a/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
@@ -1,0 +1,17 @@
+var env;
+var run = Ember.run;
+
+module('integration/serializer/json-api - JSONAPISerializer', {
+  setup: function() {
+    env = setupStore({
+    });
+  },
+
+  teardown: function() {
+    run(env.store, 'destroy');
+  }
+});
+
+/*test('...', function() {
+
+});*/

--- a/packages/ember-data/tests/unit/serializers/json-api-serializer-test.js
+++ b/packages/ember-data/tests/unit/serializers/json-api-serializer-test.js
@@ -1,0 +1,20 @@
+module('unit/serializers/json-api-serializer');
+
+test('transformFor returns the appropriate transform', function () {
+  expect(2);
+
+  var booleanTransform = {};
+
+  var serializer = DS.JSONAPISerializer.create({
+    container: {
+      lookup: function (name) {
+        equal(name, 'transform:boolean');
+        return booleanTransform;
+      }
+    }
+  });
+
+  var transform = serializer.transformFor('boolean');
+
+  equal(transform, booleanTransform, 'transform is correct.');
+});

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -486,23 +486,26 @@ test('Calling push with a link for a non async relationship should warn', functi
   }, /You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the association is not an async relationship./);
 });
 
-test('Calling push with a link containing an object throws an assertion error', function() {
+test('Calling push with a link containing an object', function() {
   Person.reopen({
     phoneNumbers: hasMany('phone-number', { async: true })
   });
 
-  expectAssertion(function() {
-    run(function() {
-      store.push('person', {
-        id: '1',
-        links: {
-          phoneNumbers: {
-            href: '/api/people/1/phone-numbers'
-          }
+  run(function() {
+    store.push('person', {
+      id: '1',
+      firstName: 'Tan',
+      links: {
+        phoneNumbers: {
+          href: '/api/people/1/phone-numbers'
         }
-      });
+      }
     });
-  }, "You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the value of that link is not a string.");
+  });
+
+  var person = store.getById('person', 1);
+
+  equal(person.get('firstName'), "Tan", "you can use links that contain an object as a value");
 });
 
 test('Calling push with a link containing the value null', function() {

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -82,12 +82,15 @@
     registry.optionsForType('adapter', { singleton: false });
 
     registry.register('serializer:-default', DS.JSONSerializer);
+    registry.register('serializer:-json-api', DS.JSONAPISerializer);
     registry.register('serializer:-rest', DS.RESTSerializer);
+    registry.register('adapter:-json-api', DS.JSONAPIAdapter);
     registry.register('adapter:-rest', DS.RESTAdapter);
 
     registry.injection('serializer', 'store', 'store:main');
 
     env.serializer = container.lookup('serializer:-default');
+    env.jsonApiSerializer = container.lookup('serializer:-json-api');
     env.restSerializer = container.lookup('serializer:-rest');
     env.store = container.lookup('store:main');
     env.adapter = env.store.get('defaultAdapter');
@@ -118,11 +121,11 @@
     };
 
     // Prevent all tests involving serialization to require a container
-    DS.JSONSerializer.reopen({
-      transformFor: function(attributeType) {
-        return this._super(attributeType, true) || transforms[attributeType];
-      }
-    });
+    var transformFor = function(attributeType) {
+      return this._super(attributeType, true) || transforms[attributeType];
+    };
+    DS.JSONSerializer.reopen({ transformFor: transformFor });
+    DS.JSONAPISerializer.reopen({ transformFor: transformFor });
 
   });
 


### PR DESCRIPTION
`transformFor` is missing on JSONAPISerializer, so applyTransforms() will fail. This PR copies in the implementation from `json-serializer`.

The failure wasn't showing up in the adapter tests because a mock `transformFor` is injected at QUnit initialization time as a convenience for integration tests. I refactored the injection to happen on demand.
